### PR TITLE
Add websockets feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Custom
+/target
+
 # Created by .ignore support plugin (hsz.mobi)
 .metadata
 bin/

--- a/README.md
+++ b/README.md
@@ -56,6 +56,40 @@ public class Main {
 }
 ```
 
+### With WebSockets
+
+Very similar to the example above. Be aware that you **need** to set a context path for the REST resources, otherwise jetty will throw you some errors when connecting with websockets. Be sure that a REST resource does not have the same path as a websocket resource. This is currently the only known limitation. The advantage is that a single jetty server runs with REST and WebSockets enabled on the same port.
+
+1. Add `JerseyModule` to your Guice Injector
+2. Configure packages to scan for resources and a port to expose
+3. Get instance of `JerseyServer` and start consuming your Restful and WebSocket resources
+
+```java
+public class Main {
+    public static void main(String[] args) throws Exception {
+        JerseyConfiguration configuration = JerseyConfiguration.builder()
+            .addPackage("com.example.resources")
+            .withContextPath("resources") // enter a value here, just not "/"
+            .addPort(8080)
+            .build();
+        WebsocketConfiguration wsConfig = new WebsocketConfiguration()
+            .withEndpointClasses(...) // add your classes that have the javax.websocket annotations.
+        
+        List<Module> modules = new ArrayList<>();        
+        modules.add(new JerseyModule(configuration, wsConfig));
+        modules.add(new AbstractModule() {
+          @Override
+          protected void configure() {
+            // Your module bindings ...
+          }
+        });
+        
+        Guice.createInjector(modules)
+          .getInstance(JerseyServer.class).start();
+    }
+}
+```
+
 ## Motivation
 
 ### Why Jersey?

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,21 @@
             <artifactId>guice</artifactId>
             <version>${guice.version}</version>
         </dependency>
+        <dependency>
+            <groupId>javax.websocket</groupId>
+            <artifactId>javax.websocket-api</artifactId>
+            <version>1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>javax-websocket-server-impl</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>javax-websocket-client-impl</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>
@@ -223,6 +238,7 @@
             <version>2.8.5</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>

--- a/src/main/java/io/logz/guice/jersey/AbstractContextConfigurator.java
+++ b/src/main/java/io/logz/guice/jersey/AbstractContextConfigurator.java
@@ -1,0 +1,18 @@
+package io.logz.guice.jersey;
+
+import com.google.inject.Injector;
+import org.eclipse.jetty.server.Server;
+
+import java.util.function.Supplier;
+
+class AbstractContextConfigurator {
+
+    protected final Server server;
+    protected final Supplier<Injector> injectorSupplier;
+
+    AbstractContextConfigurator(Server server, Supplier<Injector> injectorSupplier) {
+        this.server = server;
+        this.injectorSupplier = injectorSupplier;
+    }
+
+}

--- a/src/main/java/io/logz/guice/jersey/GuiceConfigurator.java
+++ b/src/main/java/io/logz/guice/jersey/GuiceConfigurator.java
@@ -1,0 +1,20 @@
+package io.logz.guice.jersey;
+
+import com.google.inject.Injector;
+
+import javax.websocket.server.ServerEndpointConfig;
+import java.util.function.Supplier;
+
+public class GuiceConfigurator extends ServerEndpointConfig.Configurator {
+
+    private final Supplier<Injector> injectorSupplier;
+
+    GuiceConfigurator(Supplier<Injector> injectorSupplier){
+        this.injectorSupplier = injectorSupplier;
+    }
+
+    @Override
+    public <T> T getEndpointInstance(Class<T> endpointClass) throws InstantiationException {
+        return injectorSupplier.get().getInstance(endpointClass);
+    }
+}

--- a/src/main/java/io/logz/guice/jersey/JerseyModule.java
+++ b/src/main/java/io/logz/guice/jersey/JerseyModule.java
@@ -5,23 +5,45 @@ import com.google.inject.Injector;
 import com.google.inject.Provider;
 import com.google.inject.servlet.ServletModule;
 import io.logz.guice.jersey.configuration.JerseyConfiguration;
+import io.logz.guice.jersey.configuration.WebsocketConfiguration;
 
 import java.util.Objects;
 
 public class JerseyModule extends AbstractModule {
 
     private final JerseyConfiguration jerseyConfiguration;
+    private final WebsocketConfiguration websocketConfiguration;
 
+    /**
+     * Creates a module that enables the REST resources.
+     *
+     * @param jerseyConfiguration the config, not null.
+     * @throws NullPointerException if jerseyConfiguration is null.
+     */
     public JerseyModule(JerseyConfiguration jerseyConfiguration) {
+        this(jerseyConfiguration, null);
+    }
+
+    /**
+     * Creates a module that enables the REST resources and the websocket feature.
+     *
+     * @param jerseyConfiguration    the config, not null.
+     * @param websocketConfiguration the websocket configuration. Can be null, in which case websockets will be disabled.
+     * @throws NullPointerException if jerseyConfiguration is null.
+     */
+    public JerseyModule(JerseyConfiguration jerseyConfiguration, WebsocketConfiguration websocketConfiguration) {
         this.jerseyConfiguration = Objects.requireNonNull(jerseyConfiguration);
+        this.websocketConfiguration = websocketConfiguration;
     }
 
     protected void configure() {
         Provider<Injector> injectorProvider = getProvider(Injector.class);
 
         install(new ServletModule());
-        bind(JerseyServer.class).toInstance(new JerseyServer(jerseyConfiguration, injectorProvider::get));
+        bind(JerseyServer.class).toInstance(new JerseyServer(
+                jerseyConfiguration, websocketConfiguration, injectorProvider::get));
         bind(JerseyConfiguration.class).toInstance(jerseyConfiguration);
+        if (websocketConfiguration != null) bind(WebsocketConfiguration.class).toInstance(websocketConfiguration);
     }
 
 }

--- a/src/main/java/io/logz/guice/jersey/RestContextConfigurator.java
+++ b/src/main/java/io/logz/guice/jersey/RestContextConfigurator.java
@@ -1,0 +1,44 @@
+package io.logz.guice.jersey;
+
+import com.google.inject.Injector;
+import com.google.inject.servlet.GuiceFilter;
+import com.google.inject.servlet.GuiceServletContextListener;
+import io.logz.guice.jersey.configuration.JerseyConfiguration;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.glassfish.jersey.servlet.ServletContainer;
+
+import javax.servlet.DispatcherType;
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+class RestContextConfigurator extends AbstractContextConfigurator {
+
+    RestContextConfigurator(Server server, Supplier<Injector> injectorSupplier){
+        super(server, injectorSupplier);
+    }
+
+    Optional<ContextHandler> configure(JerseyConfiguration jerseyConfiguration) {
+        WebAppContext webAppContext = new WebAppContext();
+        webAppContext.setServer(server);
+
+        webAppContext.addFilter(GuiceFilter.class, "/*", EnumSet.allOf(DispatcherType.class));
+
+        ServletHolder holder = new ServletHolder(ServletContainer.class);
+        holder.setInitParameter("javax.ws.rs.Application", GuiceJerseyResourceConfig.class.getName());
+
+        webAppContext.addServlet(holder, "/*");
+        webAppContext.setResourceBase("/");
+        webAppContext.setContextPath(jerseyConfiguration.getContextPath());
+        webAppContext.addEventListener(new GuiceServletContextListener() {
+            @Override
+            protected Injector getInjector() {
+                return injectorSupplier.get();
+            }
+        });
+        return Optional.of(webAppContext);
+    }
+}

--- a/src/main/java/io/logz/guice/jersey/WebsocketContextConfigurator.java
+++ b/src/main/java/io/logz/guice/jersey/WebsocketContextConfigurator.java
@@ -1,0 +1,70 @@
+package io.logz.guice.jersey;
+
+import com.google.inject.Injector;
+import io.logz.guice.jersey.configuration.WebsocketConfiguration;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.websocket.api.InvalidWebSocketException;
+import org.eclipse.jetty.websocket.jsr356.server.deploy.WebSocketServerContainerInitializer;
+
+import javax.servlet.ServletException;
+import javax.websocket.DeploymentException;
+import javax.websocket.server.ServerContainer;
+import javax.websocket.server.ServerEndpoint;
+import javax.websocket.server.ServerEndpointConfig;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+class WebsocketContextConfigurator extends AbstractContextConfigurator {
+
+    WebsocketContextConfigurator(Server server, Supplier<Injector> injectorSupplier) {
+        super(server, injectorSupplier);
+    }
+
+    Optional<ContextHandler> configure(WebsocketConfiguration configuration) {
+
+        if (configuration == null) return Optional.empty();
+
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+        context.setContextPath("/");
+        context.setServer(server);
+
+        try {
+            ServerContainer wsContainer = WebSocketServerContainerInitializer.configureContext(context);
+            GuiceConfigurator configurator = new GuiceConfigurator(injectorSupplier);
+            configuration.getEndpointClasses().forEach(endpointClass -> {
+                try {
+                    ServerEndpointConfig config = createEndpointConfig(
+                            endpointClass, configurator);
+                    wsContainer.addEndpoint(config);
+                } catch (DeploymentException e) {
+                    throw new InvalidWebSocketException("Cannot add endpoint " + endpointClass.getName(), e);
+                }
+            });
+
+            return Optional.of(context);
+        } catch (ServletException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private ServerEndpointConfig createEndpointConfig(
+            Class<?> endpointClass,
+            GuiceConfigurator configurator) {
+
+        ServerEndpoint annotation = endpointClass.getAnnotation(ServerEndpoint.class);
+        if (annotation == null) {
+            throw new InvalidWebSocketException("Unsupported WebSocket object, missing @" + ServerEndpoint.class + " annotation");
+        }
+
+        return ServerEndpointConfig.Builder.create(endpointClass, annotation.value())
+                .subprotocols(Arrays.asList(annotation.subprotocols()))
+                .decoders(Arrays.asList(annotation.decoders()))
+                .encoders(Arrays.asList(annotation.encoders()))
+                .configurator(configurator)
+                .build();
+    }
+
+}

--- a/src/main/java/io/logz/guice/jersey/configuration/WebsocketConfiguration.java
+++ b/src/main/java/io/logz/guice/jersey/configuration/WebsocketConfiguration.java
@@ -1,0 +1,27 @@
+package io.logz.guice.jersey.configuration;
+
+import java.util.*;
+
+public class WebsocketConfiguration {
+
+    private List<Class<?>> endpointClasses = new ArrayList<>();
+
+    public List<Class<?>> getEndpointClasses() {
+        return Collections.unmodifiableList(endpointClasses);
+    }
+
+    public WebsocketConfiguration withEndpointClass(Class<?> endpointClass) {
+        Objects.requireNonNull(endpointClass);
+        endpointClasses.add(endpointClass);
+        return this;
+    }
+
+    public WebsocketConfiguration withEndpointClasses(Class<?>... endpointClasses) {
+        Objects.requireNonNull(endpointClasses);
+        for (Class<?> endpointClass : endpointClasses) {
+            withEndpointClass(endpointClass);
+        }
+        return this;
+    }
+
+}

--- a/src/test/java/io/logz/guice/jersey/WebsocketServerTest.java
+++ b/src/test/java/io/logz/guice/jersey/WebsocketServerTest.java
@@ -1,0 +1,66 @@
+package io.logz.guice.jersey;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+import io.logz.guice.jersey.configuration.JerseyConfiguration;
+import io.logz.guice.jersey.configuration.JerseyConfigurationBuilder;
+import io.logz.guice.jersey.configuration.WebsocketConfiguration;
+import io.logz.guice.jersey.resources.TestResource;
+import io.logz.guice.jersey.resources.TestSocket;
+import io.logz.guice.jersey.supplier.WebsocketServerSupplier;
+import org.junit.Test;
+
+import javax.websocket.Session;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WebsocketServerTest {
+
+    @Test
+    public void testContextPathConfiguration() throws Exception {
+        JerseyConfigurationBuilder configurationBuilder = JerseyConfiguration.builder()
+                .withContextPath("resources")
+                .addResourceClass(TestResource.class);
+
+        WebsocketConfiguration websocketConfiguration = new WebsocketConfiguration()
+                .withEndpointClass(TestSocket.class);
+
+        String message = "hello world";
+        AtomicBoolean called = new AtomicBoolean();
+
+        new WebsocketServerSupplier(configurationBuilder, websocketConfiguration)
+                .createServerAndTest(
+                        createTester(
+                                session -> session.getBasicRemote().sendText(message),
+                                new AbstractModule() {
+                                    @Override
+                                    protected void configure() {
+                                        bind(TestSocket.SocketCallback.class).toInstance(s -> {
+                                            assertThat(s).isEqualTo(message);
+                                            called.set(true);
+                                        });
+                                    }
+                                }));
+
+        assertThat(called).isTrue();
+    }
+
+    private WebsocketServerSupplier.Tester createTester(Callable consumer, Module module) {
+        return new WebsocketServerSupplier.Tester() {
+            @Override
+            public void test(Session session) throws Exception {
+                consumer.test(session);
+            }
+
+            @Override
+            public Module getTestModule() {
+                return module;
+            }
+        };
+    }
+
+    private interface Callable {
+        void test(Session session) throws Exception;
+    }
+}

--- a/src/test/java/io/logz/guice/jersey/resources/TestSocket.java
+++ b/src/test/java/io/logz/guice/jersey/resources/TestSocket.java
@@ -1,0 +1,53 @@
+package io.logz.guice.jersey.resources;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.websocket.*;
+import javax.websocket.server.ServerEndpoint;
+import java.util.function.Consumer;
+
+
+@ClientEndpoint
+@ServerEndpoint(value = "/ws/test")
+public class TestSocket {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestSocket.class);
+    private final SocketCallback callback;
+
+    @Inject
+    TestSocket(SocketCallback callback){
+        this.callback = callback;
+    }
+
+    @OnOpen
+    public void onWebSocketConnect(Session session)
+    {
+        LOGGER.info("Socket Connected: " + session);
+    }
+
+    @OnMessage
+    public void onWebSocketText(String message)
+    {
+        LOGGER.info("Received TEXT message: " + message);
+        callback.accept(message);
+    }
+
+    @OnClose
+    public void onWebSocketClose(CloseReason reason)
+    {
+        LOGGER.info("Socket Closed: " + reason);
+    }
+
+    @OnError
+    public void onWebSocketError(Throwable cause)
+    {
+        LOGGER.info("catching: ", cause);
+    }
+
+    public interface SocketCallback extends Consumer<String> {
+
+    }
+
+}

--- a/src/test/java/io/logz/guice/jersey/supplier/WebsocketServerSupplier.java
+++ b/src/test/java/io/logz/guice/jersey/supplier/WebsocketServerSupplier.java
@@ -49,7 +49,10 @@ public class WebsocketServerSupplier {
             Object instance = injector.getInstance(endpointClass);
             Session session = ContainerProvider.getWebSocketContainer().connectToServer(instance, uri);
 
+            // wait some time to make sure everything's ready.
+            Thread.sleep(20);
             tester.test(session);
+            Thread.sleep(20);
             session.close();
         } finally {
             server.stop();

--- a/src/test/java/io/logz/guice/jersey/supplier/WebsocketServerSupplier.java
+++ b/src/test/java/io/logz/guice/jersey/supplier/WebsocketServerSupplier.java
@@ -1,0 +1,76 @@
+package io.logz.guice.jersey.supplier;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import io.logz.guice.jersey.JerseyModule;
+import io.logz.guice.jersey.JerseyServer;
+import io.logz.guice.jersey.configuration.JerseyConfigurationBuilder;
+import io.logz.guice.jersey.configuration.WebsocketConfiguration;
+import org.apache.mina.util.AvailablePortFinder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.websocket.ContainerProvider;
+import javax.websocket.Session;
+import javax.websocket.server.ServerEndpoint;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class WebsocketServerSupplier {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WebsocketServerSupplier.class);
+    private final JerseyConfigurationBuilder configurationBuilder;
+    private final WebsocketConfiguration websocketConfiguration;
+
+    public WebsocketServerSupplier(JerseyConfigurationBuilder configurationBuilder,
+                                   WebsocketConfiguration websocketConfiguration) {
+        this.configurationBuilder = configurationBuilder;
+        this.websocketConfiguration = websocketConfiguration;
+    }
+
+    public void createServerAndTest(Tester tester) throws Exception {
+
+        int port = AvailablePortFinder.getNextAvailable();
+        configurationBuilder.addPort(port);
+
+        JerseyServer server = createServer(tester);
+        try {
+            server.start();
+            LOGGER.info("Started server on port: {}", port);
+
+            Class<?> endpointClass = websocketConfiguration.getEndpointClasses().get(0);
+            String path = endpointClass.getAnnotation(ServerEndpoint.class).value();
+            URI uri = URI.create("ws://localhost:" + port + path);
+
+            Injector injector = Guice.createInjector(tester.getTestModule());
+            Object instance = injector.getInstance(endpointClass);
+            Session session = ContainerProvider.getWebSocketContainer().connectToServer(instance, uri);
+
+            tester.test(session);
+            session.close();
+        } finally {
+            server.stop();
+        }
+    }
+
+    private JerseyServer createServer(Tester tester) {
+
+        List<Module> modules = new ArrayList<>();
+        modules.add(new JerseyModule(configurationBuilder.build(), websocketConfiguration));
+        modules.add(tester.getTestModule());
+
+        return Guice.createInjector(modules)
+                .getInstance(JerseyServer.class);
+    }
+
+    public interface Tester {
+
+        void test(Session session) throws Exception;
+
+        Module getTestModule();
+
+    }
+}


### PR DESCRIPTION
Hi. I'm using guice-jersey in one of my projects and wanted to try websockets. Instead of initializing another jetty server and consuming twice the memory, I thought about integrating websockets into this project, so that a browser may receive updates without polling but still have a restful API for the request/response operations. 

However there is a restriction on the context path, if websockets are enabled. This is described in the readme. Websockets will add another few of dependencies, even if disabled. I tried to make them optional, but I failed doing so. They are just a few hundred KBs, so it's not too bad.

The implementation is actually based on your project guice-websocket ;)