### PR TITLE
Add thread name prefix to Jetty's thread pool

### DIFF
--- a/src/main/java/io/logz/guice/jersey/JerseyServer.java
+++ b/src/main/java/io/logz/guice/jersey/JerseyServer.java
@@ -8,6 +8,8 @@ import io.logz.guice.jersey.configuration.ServerConnectorConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
@@ -54,6 +56,10 @@ public class JerseyServer {
             connector.setPort(configuration.getPort());
             server.addConnector(connector);
         });
+
+        if(StringUtil.isNotBlank(jerseyConfiguration.getThreadsNamePrefix())) {
+            ((QueuedThreadPool) this.server.getThreadPool()).setName(jerseyConfiguration.getThreadsNamePrefix());
+        }
 
         WebAppContext webAppContext = new WebAppContext();
         webAppContext.setServer(server);

--- a/src/main/java/io/logz/guice/jersey/configuration/JerseyConfiguration.java
+++ b/src/main/java/io/logz/guice/jersey/configuration/JerseyConfiguration.java
@@ -10,6 +10,7 @@ public class JerseyConfiguration {
     private final List<ServerConnectorConfiguration> serverConnectors;
     private final ResourceConfig resourceConfig;
     private final String contextPath;
+    private final String threadsNamePrefix;
 
     public static JerseyConfigurationBuilder builder() {
         return new JerseyConfigurationBuilder();
@@ -17,10 +18,12 @@ public class JerseyConfiguration {
 
     JerseyConfiguration(List<ServerConnectorConfiguration> serverConnectors,
                         ResourceConfig resourceConfig,
-                        String contextPath) {
+                        String contextPath,
+                        String threadsNamePrefix) {
         this.serverConnectors = Objects.requireNonNull(serverConnectors);
         this.resourceConfig = Objects.requireNonNull(resourceConfig);
         this.contextPath = appendLeadingSlashIfMissing(contextPath);
+        this.threadsNamePrefix = threadsNamePrefix;
 
         if (serverConnectors.size() == 0) {
             throw new RuntimeException("Must supply at least one server connector");
@@ -39,6 +42,10 @@ public class JerseyConfiguration {
         return contextPath;
     }
 
+    public String getThreadsNamePrefix() {
+        return threadsNamePrefix;
+    }
+
     private String appendLeadingSlashIfMissing(String contextRoot) {
         contextRoot = Objects.requireNonNull(contextRoot);
         if (!contextRoot.startsWith("/")) {
@@ -47,5 +54,4 @@ public class JerseyConfiguration {
 
         return contextRoot;
     }
-
 }

--- a/src/main/java/io/logz/guice/jersey/configuration/JerseyConfigurationBuilder.java
+++ b/src/main/java/io/logz/guice/jersey/configuration/JerseyConfigurationBuilder.java
@@ -15,6 +15,7 @@ public class JerseyConfigurationBuilder {
     private Map<String, Boolean> packages;
     private ResourceConfig resourceConfig;
     private Set<ServerConnectorConfiguration> connectors;
+    private String threadsNamePrefix;
 
     JerseyConfigurationBuilder() {
         contextPath = "";
@@ -30,6 +31,11 @@ public class JerseyConfigurationBuilder {
 
     public JerseyConfigurationBuilder withResourceConfig(ResourceConfig resourceConfig) {
         this.resourceConfig = resourceConfig;
+        return this;
+    }
+
+    public JerseyConfigurationBuilder withThreadsNamePrefix(String threadsNamePrefix) {
+        this.threadsNamePrefix = threadsNamePrefix;
         return this;
     }
 
@@ -74,7 +80,7 @@ public class JerseyConfigurationBuilder {
         resourceConfig.registerClasses(classes);
         packages.forEach((packageToScan, recursive) -> resourceConfig.packages(recursive, packageToScan));
 
-        return new JerseyConfiguration(new ArrayList<>(connectors), resourceConfig, contextPath);
+        return new JerseyConfiguration(new ArrayList<>(connectors), resourceConfig, contextPath, threadsNamePrefix);
     }
 
 }


### PR DESCRIPTION
Not the most elegant solution but I can't find anything better
The alternative to this implementation is to expose Jetty's JMX beans and set org.eclipse.jetty.util.thread.QueuedThreadPool.name using JMX
I would really like to see an engine's name in the thread names rather than qtp***