### PR TITLE
Jetty dependency: upgrade to major version 10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hk2-bridge.version>2.6.0</hk2-bridge.version>
         <jersey.version>2.29</jersey.version>
-        <jetty.version>9.4.28.v20200408</jetty.version>
+        <jetty.version>10.0.8</jetty.version>
         <guice.version>4.2.2</guice.version>
         <slf4j.version>1.7.26</slf4j.version>
         <jackson.version>2.10.2</jackson.version>


### PR DESCRIPTION
The current jetty version has a few vulnerabilities as seen in https://mvnrepository.com/artifact/io.logz/guice-jersey/1.0.16.